### PR TITLE
Pass additional arguments to `staging restore`.

### DIFF
--- a/lib/parity/backup.rb
+++ b/lib/parity/backup.rb
@@ -4,6 +4,7 @@ module Parity
   class Backup
     def initialize(args)
       @from, @to = args.values_at(:from, :to)
+      @additional_args = args[:additional_args] || ""
     end
 
     def restore
@@ -14,9 +15,11 @@ module Parity
       end
     end
 
-    private
+    protected
 
-    attr_reader :from, :to
+    attr_reader :additional_args, :from, :to
+
+    private
 
     def restore_to_development
       Kernel.system "#{curl} | #{pg_restore}"
@@ -31,7 +34,10 @@ module Parity
     end
 
     def restore_to_pass_through
-      Kernel.system "heroku pgbackups:restore #{backup_from} --remote #{to}"
+      Kernel.system(
+        "heroku pgbackups:restore #{backup_from} --remote #{to} "\
+          "#{additional_args}"
+      )
     end
 
     def backup_from

--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -39,7 +39,11 @@ module Parity
         $stdout.puts "Parity does not support restoring backups into your "\
           "production environment."
       else
-        Backup.new(from: arguments.first, to: environment).restore
+        Backup.new(
+          from: arguments.first,
+          to: environment,
+          additional_args: arguments.drop(1).join(" ")
+        ).restore
       end
     end
 

--- a/spec/backup_spec.rb
+++ b/spec/backup_spec.rb
@@ -1,24 +1,37 @@
 require File.join(File.dirname(__FILE__), '..', 'lib', 'parity')
 
 describe Parity::Backup do
-  it 'restores backups to development' do
+  it "restores backups to development" do
     Parity.configure do |config|
       config.database_config_path = database_config_path
     end
 
     allow(Kernel).to receive(:system)
 
-    Parity::Backup.new(from: 'production', to: 'development').restore
+    Parity::Backup.new(from: "production", to: "development").restore
 
     expect(Kernel).to have_received(:system).with(curl_piped_to_pg_restore)
   end
 
-  it 'restores backups to staging' do
+  it "restores backups to staging" do
     allow(Kernel).to receive(:system)
 
-    Parity::Backup.new(from: 'production', to: 'staging').restore
+    Parity::Backup.new(from: "production", to: "staging").restore
 
     expect(Kernel).to have_received(:system).with(heroku_pass_through)
+  end
+
+  it "passes additional arguments to the subcommand" do
+    allow(Kernel).to receive(:system)
+
+    Parity::Backup.new(
+      from: "production",
+      to: "staging",
+      additional_args: "--confirm thisismyapp-staging"
+    ).restore
+
+    expect(Kernel).
+      to have_received(:system).with(additional_argument_pass_through)
   end
 
   def database_config_path
@@ -34,6 +47,12 @@ describe Parity::Backup do
   end
 
   def heroku_pass_through
-    "heroku pgbackups:restore DATABASE `heroku pgbackups:url --remote production` --remote staging"
+    "heroku pgbackups:restore DATABASE `heroku pgbackups:url "\
+      "--remote production` --remote staging "
+  end
+
+  def additional_argument_pass_through
+    "heroku pgbackups:restore DATABASE `heroku pgbackups:url "\
+      "--remote production` --remote staging --confirm thisismyapp-staging"
   end
 end

--- a/spec/environment_spec.rb
+++ b/spec/environment_spec.rb
@@ -16,7 +16,25 @@ describe Parity::Environment do
     Parity::Environment.new("staging", ["restore", "production"]).run
 
     expect(Parity::Backup).to have_received(:new).
-      with(from: "production", to: "staging")
+      with(from: "production", to: "staging", additional_args: "")
+    expect(backup).to have_received(:restore)
+  end
+
+  it "passes arguments to the restore command when used against staging" do
+    backup = double("backup", restore: nil)
+    allow(Parity::Backup).to receive(:new).and_return(backup)
+
+    Parity::Environment.new(
+      "staging",
+      ["restore", "production", "--confirm", "myappname-staging"]
+    ).run
+
+    expect(Parity::Backup).to have_received(:new).
+      with(
+        from: "production",
+        to: "staging",
+        additional_args: "--confirm myappname-staging"
+      )
     expect(backup).to have_received(:restore)
   end
 
@@ -27,7 +45,7 @@ describe Parity::Environment do
     Parity::Environment.new("development", ["restore", "production"]).run
 
     expect(Parity::Backup).to have_received(:new).
-      with(from: "production", to: "development")
+      with(from: "production", to: "development", additional_args: "")
     expect(backup).to have_received(:restore)
   end
 
@@ -38,7 +56,7 @@ describe Parity::Environment do
     Parity::Environment.new("development", ["restore", "staging"]).run
 
     expect(Parity::Backup).to have_received(:new).
-      with(from: "staging", to: "development")
+      with(from: "staging", to: "development", additional_args: "")
     expect(backup).to have_received(:restore)
   end
 


### PR DESCRIPTION
This change allows the use of additional arguments (specifically the
`--confirm` switch) to `restore` when used with `staging`.

Closes #20.