### PR TITLE
Pass subcommands to shims

### DIFF
--- a/packaging/development_shim.sh
+++ b/packaging/development_shim.sh
@@ -6,4 +6,4 @@ REALPATH=$(readlink $0 || $0)
 RELATIVE_DIR=$(dirname $REALPATH)
 SELF_DIR=$(cd $(dirname $0) && cd $RELATIVE_DIR && pwd)
 
-exec "$SELF_DIR/../lib/ruby/bin/ruby" "$SELF_DIR/../lib/app/bin/development"
+exec "$SELF_DIR/../lib/ruby/bin/ruby" "$SELF_DIR/../lib/app/bin/development" "$@"

--- a/packaging/production_shim.sh
+++ b/packaging/production_shim.sh
@@ -6,4 +6,4 @@ REALPATH=$(readlink $0 || $0)
 RELATIVE_DIR=$(dirname $REALPATH)
 SELF_DIR=$(cd $(dirname $0) && cd $RELATIVE_DIR && pwd)
 
-exec "$SELF_DIR/../lib/ruby/bin/ruby" "$SELF_DIR/../lib/app/bin/production"
+exec "$SELF_DIR/../lib/ruby/bin/ruby" "$SELF_DIR/../lib/app/bin/production" "$@"

--- a/packaging/staging_shim.sh
+++ b/packaging/staging_shim.sh
@@ -6,4 +6,4 @@ REALPATH=$(readlink $0 || $0)
 RELATIVE_DIR=$(dirname $REALPATH)
 SELF_DIR=$(cd $(dirname $0) && cd $RELATIVE_DIR && pwd)
 
-exec "$SELF_DIR/../lib/ruby/bin/ruby" "$SELF_DIR/../lib/app/bin/staging"
+exec "$SELF_DIR/../lib/ruby/bin/ruby" "$SELF_DIR/../lib/app/bin/staging" "$@"


### PR DESCRIPTION
The last line of each shim is (e.g.):

```
exec "$SELF_DIR/../lib/ruby/bin/ruby" "$SELF_DIR/../lib/app/bin/staging"
```

Note that this is running `staging` and not passing along any arguments passed
to the shim, so all subcommands are ignored. Running `staging open` is passed
along as just `staging`.

The fix is to pass along arguments passed to the shim with `"$@"`:

```
exec "$SELF_DIR/../lib/ruby/bin/ruby" "$SELF_DIR/../lib/app/bin/staging" "$@"
```